### PR TITLE
Revert "chore: use librepo"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,6 @@ runs:
           $BOOTC_IMAGE_BUILDER_IMAGE \
           --type iso \
           --local \
-          --use-librepo=True \
           --chown $DESIRED_UID:$DESIRED_GID \
           $IMAGE
 


### PR DESCRIPTION
Reverts ublue-os/bootc-image-builder-action#8

The Image Builder team are investigating why new CentOS BIB images aren't being published.  We can't use this flag until they push new builds