### PR TITLE
fix: do not directly pass in input parameters for use-librepo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,7 @@ runs:
         mkdir -p ./output
         
         USE_LIBREPO_FLAG=""
-        [[ "$USE_LIBREPO" == "true" ]]; then
+        if [[ "$USE_LIBREPO" == "true" ]]; then
           USE_LIBREPO_FLAG="--use-librepo=True"
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -70,8 +70,9 @@ runs:
         CONFIG_FILE_EXTENSION="${CONFIG_FILE##*.}"
         mkdir -p ./output
         
-        if [ "$USE_LIBREPO" != "false" ] ; then
-          USE_LIBREPO="--use-librepo=True"
+        USE_LIBREPO_FLAG=""
+        [[ "$USE_LIBREPO" == "true" ]]; then
+          USE_LIBREPO_FLAG="--use-librepo=True"
         fi
 
         sudo podman run \
@@ -86,7 +87,8 @@ runs:
           --type iso \
           --local \
           --chown $DESIRED_UID:$DESIRED_GID \
-          $USE_LIBREPO $IMAGE
+          $USE_LIBREPO_FLAG \
+          $IMAGE
 
           ISO_PATH=$(ls ./output/bootiso/*.iso)
 


### PR DESCRIPTION
Since the USE_LIBREPO environment variable name is the same as the name of the variable containing the flag, even when passed false, the string is used in the podman run command.

E.G.
```
        sudo podman run \
          --rm \
          --privileged \
          --pull=newer \
          --security-opt label=type:unconfined_t \
          -v $CONFIG_FILE:/config.$CONFIG_FILE_EXTENSION:ro \
          -v ./output:/output \
          -v /var/lib/containers/storage:/var/lib/containers/storage \
          $BOOTC_IMAGE_BUILDER_IMAGE \
          --type iso \
          --local \
          --chown $DESIRED_UID:$DESIRED_GID \
          false \
          my-image:local
```

This sets separate variables for the flag and the input