### PR TITLE
fix: Don't rely on the default behavior of parameters

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ runs:
         mkdir -p ./output
 
         INPUT_ARGS=""
-        [ "${USE_LIBREPO}" == "true" ] && INPUT_ARGS+="--use-librepo=True "
+        [ "${USE_LIBREPO}" == "true" ] && INPUT_ARGS+="--use-librepo=True " || INPUT_ARGS+="--use-librepo=False "
         [ -n "${ROOTFS}" ] && INPUT_ARGS+="--rootfs=${ROOTFS} "
 
         sudo podman run \

--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,11 @@ runs:
         mkdir -p ./output
 
         INPUT_ARGS=""
-        [ "${USE_LIBREPO}" == "true" ] && INPUT_ARGS+="--use-librepo=True " || INPUT_ARGS+="--use-librepo=False "
+        if [ "${USE_LIBREPO}" == "true" ]; then
+            INPUT_ARGS+="--use-librepo=True "
+        else
+            INPUT_ARGS+="--use-librepo=False "
+        fi
         [ -n "${ROOTFS}" ] && INPUT_ARGS+="--rootfs=${ROOTFS} "
 
         sudo podman run \


### PR DESCRIPTION
Setting `use-librepo` to False no longer works because librepo is now the default behavior.